### PR TITLE
Fix the package version

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # IMPORTANT: otherwise the current tag does not get fetched and the build version gets worse
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
# Summary

Jobs like https://github.com/LeonhardSchwertfeger/GenAI-PoD/actions/runs/12704214185/job/35413304724 fail since the package version is already present at PyPI. 

In order to avoid this, we need to fetch the whole git history during package build, which fixes the version calculation.