### PR TITLE
Resolve "genai --version fails with traceback"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,7 @@ repos:
         additional_dependencies:
           - types-requests
           - undetected-chromedriver
+          - types-click
         pass_filenames: false
         args:
           - --config-file=pyproject.toml

--- a/genai_pod/cli.py
+++ b/genai_pod/cli.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any
 
+from click import echo
 from cloup import (  # type: ignore[import]
     STRING,
     Choice,
@@ -20,15 +21,36 @@ from cloup import (  # type: ignore[import]
     group,
     option,
     pass_context,
-    version_option,
 )
 
 if TYPE_CHECKING:
     from cloup import Context
 
 
+def print_version(
+    ctx: Context,
+    param: Any,  # pylint: disable=unused-argument
+    value: Any,  # noqa: ANN401, ARG001
+) -> None:
+    """Prints the version of the package"""
+    if not value or ctx.resilient_parsing:
+        return
+    from importlib.metadata import (  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
+        version,
+    )
+
+    echo(version("genai_pod"))
+    ctx.exit()
+
+
 @group()
-@version_option(message="%version%")
+@option(
+    "--version",
+    is_flag=True,
+    callback=print_version,
+    expose_value=False,
+    is_eager=True,
+)
 @pass_context
 def cli(ctx: Context, **kwargs: Any) -> None:
     """Main entry point for the command-line application.


### PR DESCRIPTION
# Summary

The `--version` option now works, as we needed to create a custom function as the `%version%` if click doesn't like the "v" within the version string.

See https://click.palletsprojects.com/en/stable/options/#callbacks-and-eager-options
