### PR TITLE
Solved #25

### DIFF
--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # GitHub: https://github.com/btschwertfeger
-#
-# Template workflow to run pre-commit.
+# Leonhard Thomas Schwertfeger https://github.com/LeonhardSchwertfeger
 #
 
 name: Pre-Commit
@@ -16,4 +15,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install pylint
+
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -13,7 +13,7 @@ jobs:
   Pre-Commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
@@ -21,8 +21,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: pip install .
+      - name: Install Dependencies
+        run: |
+          pip install .
+          pip install pylint
 
-      - name: Run pre-commit
+      - name: Run Pre-Commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pylint
+          pip install .
 
       - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: pre-commit/action@v3

--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -22,8 +22,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: |
-          pip install .
+        run: pip install .
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,19 +29,7 @@ repos:
           - --rcfile=pyproject.toml
           - -d=R0801,C0415,W0718,W0719 # ignore duplicate code and "Import outside toplevel"
           - -j=4
-        additional_dependencies:
-          - pytz
-          - requests
-          - undetected-chromedriver
-          - Pillow
-          - selenium
-          - tqdm
-          - numpy
-          - pyautogui
-          - webdriver-manager
-          - seleniumbase
-          - cloup
-          - types-click
+        language: system
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.4.2
     hooks:

--- a/genai_pod/utilitys/bigjpg_upscaler.py
+++ b/genai_pod/utilitys/bigjpg_upscaler.py
@@ -281,6 +281,7 @@ def monitor_progress(driver: webdriver.Chrome) -> str | None:
         - "image_too_big" if the image is too large.
         - None if an unexpected issue occurs.
     :raises Exception: If the progress is stuck at 0% for over 1 minute.
+    :raises Exception: If the progress is stuck below 100% for over 6 minutes.
     """
     zero_start: float | None = None
     below_start: float | None = None
@@ -314,9 +315,9 @@ def monitor_progress(driver: webdriver.Chrome) -> str | None:
             if percent < 100:
                 if below_start is None:
                     below_start = time()
-                elif time() - below_start >= 240:
+                elif time() - below_start >= 360:
                     raise Exception(
-                        "Stuck for 4 minutes under 100%.",
+                        "Stuck for 6 minutes under 100%.",
                     )
             else:
                 below_start = None


### PR DESCRIPTION
# Summary

Solution found on [Stackoverflow](https://stackoverflow.com/questions/61238318/pylint-and-pre-commit-hook-unable-to-import).

"If I understand this correctly the language: system defines that pylint will be executed from the system. Normally pre-commit creates an own environment to execute the hooks. In this environment your dependencies aren't installed, so you get an Unable to load import. You only must make sure you install pylint on your own into your environment along your dependencies." 

Closes: #25 

Closes: #41